### PR TITLE
Change buff ID for Legacy of the Emperor

### DIFF
--- a/Classes.lua
+++ b/Classes.lua
@@ -1861,7 +1861,7 @@ all:RegisterAuras({
             end
 
             -- Legacy of the Emperor
-            name, icon, count, debuffType, duration, expirationTime, caster = FindUnitBuffByID("player", 115921)
+            name, icon, count, debuffType, duration, expirationTime, caster = FindUnitBuffByID("player", 117666)
             if name then
                 t.name = name
                 t.count = 1


### PR DESCRIPTION
I found through my local testing that this change is needed in order for Hekili to stop recommending I cast Blessing of Kings when I already have Legacy of the Emperor.

Compare the following two Wowhead pages:

https://www.wowhead.com/mop-classic/spell=115921/legacy-of-the-emperor

https://www.wowhead.com/mop-classic/spell=117666/legacy-of-the-emperor