### PR TITLE
Fix for 5.5.1

### DIFF
--- a/Hekili.toc
+++ b/Hekili.toc
@@ -1,5 +1,5 @@
-## Interface: 50500
-## Version: v5.5.0-1.0.0-MoP
+## Interface: 50501
+## Version: v5.5.1-1.0.0-MoP
 ## Title: Hekili
 ## Author: Hekili
 ## X-Flavor: MoP

--- a/UI.lua
+++ b/UI.lua
@@ -1303,7 +1303,8 @@ do
                                 b.Keybinding:SetText(nil)
                             end
 
-                            if conf.glow.enabled and ( i == 1 or conf.glow.queued ) and IsSpellOverlayed( ability.id ) then
+							local overlayAPI = _G.C_SpellActivationOverlay
+							if conf.glow.enabled and ( i == 1 or conf.glow.queued ) and overlayAPI and overlayAPI.IsSpellOverlayed and overlayAPI.IsSpellOverlayed( ability.id ) then
                                 b.glowColor = b.glowColor or {}
 
                                 if conf.glow.coloring == "class" then
@@ -1357,7 +1358,8 @@ if self.HasRecommendations then
                         local a = b.Ability
 
                         if i == 1 or conf.glow.queued then
-                            local glowing = a.id > 0 and IsSpellOverlayed( a.id )
+								local overlayAPI = _G.C_SpellActivationOverlay
+								local glowing = a.id > 0 and overlayAPI and overlayAPI.IsSpellOverlayed and overlayAPI.IsSpellOverlayed( a.id )
 
                             if glowing and not b.glowing then
                                 b.glowColor = b.glowColor or {}


### PR DESCRIPTION
5.5.1 deprecated `IsSpellOverlayed` and changed to `C_SpellActivationOverlay.IsSpellOverlayed` as documented [here.](https://warcraft.wiki.gg/wiki/API_C_SpellActivationOverlay.IsSpellOverlayed)