### PR TITLE
Fix Affliction, Paladin

### DIFF
--- a/Classes.lua
+++ b/Classes.lua
@@ -1651,13 +1651,6 @@ all:RegisterAuras({
         max_stack = 1,
     },
 
-    chaos_brand = {
-        id = 1490,
-        duration = 3600,
-        type = "Magic",
-        max_stack = 1,
-        shared = "target"
-    },
     power_infusion = {
         id = 10060,
         duration = 20,
@@ -2244,6 +2237,138 @@ all:RegisterAuras({
             t.down = true
             t.remains = 0
         end
+    },
+
+    -- Spell Vulnerability family
+    magic_vulnerability = {
+        alias = {
+            "curse_of_elements",
+            "master_poisoner",
+            "fire_breath",
+            "lightning_breath"
+        },
+        aliasMode = "first",
+        aliasType = "debuff",
+        shared = "target",
+    },
+
+    curse_of_elements = {
+        id = 1490,
+        duration = 300,
+        max_stack = 1,
+        debuff = true,
+        shared = "target",
+        generate = function( t )
+            -- Try to find either 1490 or 104225
+            local name, icon, count, debuffType, duration, expirationTime, caster
+            name, icon, count, debuffType, duration, expirationTime, caster = FindUnitDebuffByID( "target", 1490 )
+            if not name then
+                name, icon, count, debuffType, duration, expirationTime, caster = FindUnitDebuffByID( "target", 104225 )
+            end
+
+            if name and caster == "player" then
+                t.name = name
+                t.count = 1
+                t.expires = expirationTime
+                t.applied = expirationTime - duration
+                t.caster = caster
+                t.duration = duration
+                return
+            end
+
+            t.count = 0
+            t.expires = 0
+            t.applied = 0
+            t.caster = "nobody"
+            t.duration = 300
+            return
+        end,
+
+        copy = { 104225 },
+    },
+
+    master_poisoner = {
+        id = 58410,
+        duration = 15,
+        max_stack = 1,
+        debuff = true,
+        shared = "target",
+        generate = function( t )
+            local name, icon, count, debuffType, duration, expirationTime, caster = FindUnitDebuffByID( "target", 58410 )
+
+            if name and caster == "player" then
+                t.name = name
+                t.count = 1
+                t.expires = expirationTime
+                t.applied = expirationTime - duration
+                t.caster = caster
+                t.duration = duration
+                return
+            end
+
+            t.count = 0
+            t.expires = 0
+            t.applied = 0
+            t.caster = "nobody"
+            t.duration = 15
+            return
+        end,
+    },
+
+    fire_breath = {
+        id = 34889,
+        duration = 15,
+        max_stack = 1,
+        debuff = true,
+        shared = "target",
+        generate = function( t )
+            local name, icon, count, debuffType, duration, expirationTime, caster = FindUnitDebuffByID( "target", 34889 )
+
+            if name and caster == "player" then
+                t.name = name
+                t.count = 1
+                t.expires = expirationTime
+                t.applied = expirationTime - duration
+                t.caster = caster
+                t.duration = duration
+                return
+            end
+
+            t.count = 0
+            t.expires = 0
+            t.applied = 0
+            t.caster = "nobody"
+            t.duration = 15
+            return
+        end,
+    },
+
+    lightning_breath = {
+        id = 24844,
+        duration = 12,
+        max_stack = 1,
+        debuff = true,
+        shared = "target",
+        generate = function( t )
+            local name, icon, count, debuffType, duration, expirationTime, caster = FindUnitDebuffByID( "target", 24844 )
+
+            if name and caster == "player" then
+                t.name = name
+                t.count = 1
+                t.expires = expirationTime
+                t.applied = expirationTime - duration
+                t.caster = caster
+                t.duration = duration
+                return
+            end
+
+            t.count = 0
+            t.expires = 0
+            t.applied = 0
+            t.caster = "nobody"
+            t.duration = 12
+            return
+        end,
     },
 
     out_of_range = {

--- a/Hekili.toc
+++ b/Hekili.toc
@@ -1,5 +1,5 @@
-## Interface: 50500
-## Version: v5.5.0-1.0.0-MoP
+## Interface: 50501
+## Version: v5.5.1-1.0.0-MoP
 ## Title: Hekili
 ## Author: Hekili
 ## X-Flavor: MoP

--- a/MistsOfPandaria/MonkWindwalker.lua
+++ b/MistsOfPandaria/MonkWindwalker.lua
@@ -251,6 +251,7 @@ local function RegisterWindwalkerSpec()
                 removeBuff("death_note")
             end
         },
+
         jab = {
             id = 100780,
             cast = 0,
@@ -268,9 +269,12 @@ local function RegisterWindwalkerSpec()
                 if talent.power_strikes.enabled and buff.power_strikes.up then
                     removeBuff("power_strikes")
                 end
-            end
+            end,
+
+            copy = { 108561, 115697, 120267, 121278, 124146, 108557, 115693 },
         },
-       tiger_palm = {
+
+        tiger_palm = {
             id = 100787,
             cast = 0,
             cooldown = 0,
@@ -595,7 +599,7 @@ local function RegisterWindwalkerSpec()
             end
         elseif event == "ADDON_LOADED" then
             local addonName = ...
-            if addonName == "Hekili" or TryRegister() then
+            if addonName == "Hekili" or TryRegister() thenf
                 self:UnregisterEvent("ADDON_LOADED")
             end
         end

--- a/MistsOfPandaria/PaladinHoly.lua
+++ b/MistsOfPandaria/PaladinHoly.lua
@@ -1,5 +1,5 @@
 -- PaladinHoly.lua
--- Updated May 28, 2025 - Modern Structure
+-- Updated Sep 28, 2025 - Modern Structure
 -- Mists of Pandaria module for Paladin: Holy spec
 
 -- MoP: Use UnitClass instead of UnitClassBase
@@ -546,11 +546,11 @@ spec:RegisterAbilities( {
         spend = 0.22,
         spendType = "mana",
         
-        startsCombat = function() return not state.option.holy_shock_heal end,
+        startsCombat = function() return not (state.settings and state.settings.holy_shock_heal) end,
         texture = 135972,
         
         handler = function()
-            if not state.option.holy_shock_heal then
+            if not (state.settings and state.settings.holy_shock_heal) then
                 -- Damage
                 -- Cast on enemy for damage
             else
@@ -753,7 +753,7 @@ spec:RegisterAbilities( {
         
         talent = "holy_prism",
         
-        startsCombat = function() return not state.option.holy_prism_heal end,
+        startsCombat = function() return not (state.settings and state.settings.holy_prism_heal) end,
         texture = 613407,
         
         handler = function()
@@ -793,7 +793,7 @@ spec:RegisterAbilities( {
         
         talent = "execution_sentence",
         
-        startsCombat = function() return not state.option.execution_sentence_heal end,
+        startsCombat = function() return not (state.settings and state.settings.execution_sentence_heal) end,
         texture = 613954,
         
         handler = function()

--- a/MistsOfPandaria/PaladinProtection.lua
+++ b/MistsOfPandaria/PaladinProtection.lua
@@ -1,5 +1,5 @@
 -- PaladinProtection.lua
--- Updated September 6, 2025 - Modern Structure
+-- Updated Sep 28, 2025 - Modern Structure
 -- Mists of Pandaria module for Paladin: Protection spec
 
 -- MoP: Use UnitClass instead of UnitClassBase
@@ -901,7 +901,7 @@ spec:RegisterAbilities( {
         
         talent = "holy_prism",
         
-        startsCombat = function() return not state.option.holy_prism_heal end,
+        startsCombat = function() return not (state.settings and state.settings.holy_prism_heal) end,
             texture = GetSpellTexture(114165),
         
         handler = function()
@@ -941,7 +941,7 @@ spec:RegisterAbilities( {
         
         talent = "execution_sentence",
         
-        startsCombat = function() return not state.option.execution_sentence_heal end,
+        startsCombat = function() return not (state.settings and state.settings.execution_sentence_heal) end,
             texture = GetSpellTexture(114157),
         
         handler = function()

--- a/MistsOfPandaria/PaladinRetribution.lua
+++ b/MistsOfPandaria/PaladinRetribution.lua
@@ -1,5 +1,5 @@
 -- PaladinRetribution.lua
--- Updated July 15, 2025 - Modern Structure
+-- Updated Sep 28, 2025 - Modern Structure
 -- Mists of Pandaria module for Paladin: Retribution spec
 
 -- MoP: Use UnitClass instead of UnitClassBase
@@ -1596,7 +1596,7 @@ spec:RegisterAbilities( {
 
         talent = "holy_prism",
 
-        startsCombat = function() return not state.option.holy_prism_heal end,
+        startsCombat = function() return not (state.settings and state.settings.holy_prism_heal) end,
         texture = 613407,
 
         handler = function()
@@ -1636,7 +1636,7 @@ spec:RegisterAbilities( {
 
         talent = "execution_sentence",
 
-        startsCombat = function() return not state.option.execution_sentence_heal end,
+        startsCombat = function() return not (state.settings and state.settings.execution_sentence_heal) end,
         texture = 613954,
 
         handler = function()

--- a/MistsOfPandaria/Priorities/WarlockAffliction.simc
+++ b/MistsOfPandaria/Priorities/WarlockAffliction.simc
@@ -1,56 +1,45 @@
-# Warlock: Affliction (Adapted from wowsims MoP APL)
-## Precombat
-actions.precombat+=/dark_intent
-actions.precombat+=/summon_pet,pet_type=felhunter
-actions.precombat+=/snapshot_stats
-actions.precombat+=/grimoire_of_sacrifice,if=talent.grimoire_of_sacrifice.enabled
-actions.precombat+=/soulburn,if=time=0&talent.soulburn.enabled
-actions.precombat+=/haunt,if=time=0
+# Warlock: Affliction
+# SimCraft 548-8
 
+actions.precombat+=/dark_intent,if=!buff.dark_intent.up
+actions.precombat+=/summon_felhunter,if=(!pet.alive&!talent.grimoire_of_sacrifice.enabled&!talent.grimoire_of_supremacy.enabled)|(talent.grimoire_of_sacrifice.enabled&!talent.grimoire_of_supremacy.enabled&buff.grimoire_of_sacrifice.down)
+actions.precombat+=/summon_observer,if=!pet.alive&talent.grimoire_of_supremacy.enabled
+actions.precombat+=/grimoire_of_sacrifice,if=talent.grimoire_of_sacrifice.enabled&pet.alive
+actions.precombat+=/potion
 
-## Default
-actions=use_item,name=trinket1,if=cooldown.dark_soul.remains<5
-actions+=/berserking,if=buff.dark_soul.up
-actions+=/blood_fury,if=buff.dark_soul.up
-actions+=/dark_soul,if=!talent.archimondes_vengeance.enabled|cooldown.archimondes_vengeance.remains>15
-actions+=/run_action_list,name=move,if=movement.remains>0
-actions+=/run_action_list,name=aoe,if=active_enemies>=5
-actions+=/run_action_list,name=st,if=active_enemies<5
+actions+=/curse_of_elements,if=debuff.magic_vulnerability.down
+actions+=/potion,if=buff.bloodlust.up|target.health.pct<=20
+actions+=/use_items
+actions+=/lifeblood
+actions+=/berserking
+actions+=/dark_soul_misery,if=!talent.archimondes_darkness.enabled|(talent.archimondes_darkness.enabled&(charges=2|trinket.proc.intellect.up|trinket.stacking_proc.intellect.up|target.health.pct<=10))
+actions+=/grimoire_of_sacrifice,if=talent.grimoire_of_sacrifice.enabled&pet.alive
+actions+=/run_action_list,name=aoe,if=active_enemies>6
+actions+=/summon_terrorguard,if=talent.grimoire_of_supremacy.enabled
+actions+=/summon_doomguard,if=!talent.grimoire_of_supremacy.enabled
+actions+=/soul_swap,if=buff.soulburn.up
+actions+=/soulburn,if=(buff.dark_soul.up|trinket.proc.intellect.up|trinket.stacking_proc.intellect.count>6)&(dot.agony.refreshable|dot.corruption.refreshable|dot.unstable_affliction.refreshable)&soul_shards>0&buff.soulburn.down
+actions+=/soulburn,if=(dot.unstable_affliction.ticks_remain<=1|dot.corruption.ticks_remain<=1|dot.agony.ticks_remain<=1)&soul_shards>0&target.health.pct<=20&buff.soulburn.down
+actions+=/soul_swap,if=active_enemies>1&buff.soul_swap.down&(buff.dark_soul.up|trinket.proc.intellect.up|trinket.stacking_proc.intellect.count>6)
+actions+=/soul_swap,cycle_targets=1,if=active_enemies>1&buff.soul_swap.up&((dot.agony.percent_increase>15&dot.agony.refreshable)|(dot.corruption.percent_increase>15&dot.corruption.refreshable)|(dot.unstable_affliction.percent_increase>15&dot.unstable_affliction.refreshable))&soul_shards>0
+actions+=/haunt,if=!haunt_in_flight&remains<cast_time+1.5&soul_shards>0
+actions+=/agony,if=dot.agony.down|(dot.agony.percent_increase>15&dot.agony.refreshable)|ticks_remain<2
+actions+=/corruption,if=dot.corruption.down|(dot.corruption.percent_increase>15&dot.corruption.refreshable)|ticks_remain<2
+actions+=/unstable_affliction,if=dot.unstable_affliction.down|(dot.unstable_affliction.percent_increase>15&dot.unstable_affliction.refreshable)|ticks_remain<2
+actions+=/summon_felhunter,if=(!pet.alive&!talent.grimoire_of_sacrifice.enabled&!talent.grimoire_of_supremacy.enabled)|(talent.grimoire_of_sacrifice.enabled&!talent.grimoire_of_supremacy.enabled&buff.grimoire_of_sacrifice.down)
+actions+=/summon_observer,if=!pet.alive&talent.grimoire_of_supremacy.enabled
+actions+=/life_tap,if=buff.dark_soul.down&buff.bloodlust.down&mana.pct<50
+actions+=/drain_soul,interrupt=1,chain=1,interrupt_if=soul_shards=4,if=target.health.pct<=20&soul_shards<4
+actions+=/malefic_grasp,interrupt=1,chain=1,interrupt_if=(target.health.pct<=20|(dot.agony.ticks_remain<2)|(dot.corruption.ticks_remain<2)|(dot.unstable_affliction.ticks_remain<2)|(dot.agony.percent_increase>15&dot.agony.refreshable)|(dot.corruption.percent_increase>15&dot.corruption.refreshable)|(dot.haunt.remains<action.haunt.cast_time+1.5))&target.health.pct>20
+actions+=/life_tap,moving=1,if=mana.pct<80&mana.pct<target.health.pct
 actions+=/fel_flame,moving=1
+actions+=/life_tap
 
-## Single Target Rotation
-# Maintain Haunt debuff; pool shards for Dark Soul when it is coming off cooldown (<10s) unless Haunt needs refresh (remains<4).
-actions.st=haunt,if=soul_shards>=1&(buff.haunting_spirits.down|buff.haunting_spirits.remains<4)
-actions.st+=/summon_doomguard,if=!talent.grimoire_of_sacrifice.enabled&active_enemies<5
-actions.st+=/summon_infernal,if=!talent.grimoire_of_sacrifice.enabled&active_enemies>=5
-actions.st+=/soulburn,if=talent.soulburn.enabled&!buff.soulburn.up&soul_shards>=1&(dot.corruption.remains>10&dot.agony.remains>10&dot.unstable_affliction.remains>8)
-actions.st+=/agony,if=remains<=tick_time|remains<9&target.time_to_die>18
-actions.st+=/unstable_affliction,if=remains<=tick_time|remains<7&target.time_to_die>15
-actions.st+=/corruption,if=remains<=tick_time|remains<5&target.time_to_die>12
-actions.st+=/dark_soul,if=(soul_shards>=4|target.health.pct<20&soul_shards>=2)&(dot.corruption.remains>10&dot.agony.remains>10&dot.unstable_affliction.remains>8)
-# Dump Haunt just before/inside Dark Soul or to avoid overcapping when not pooling.
-actions.st+=/haunt,if=buff.dark_soul.up&soul_shards>=1
-actions.st+=/haunt,if=soul_shards>=4&cooldown.dark_soul.remains>10
-actions.st+=/life_tap,if=mana.pct<40
-actions.st+=/drain_soul,interrupt=1,if=target.health.pct<20&time_to_die>tick_time*3&dot.unstable_affliction.remains>6&dot.agony.remains>6&dot.corruption.remains>6
-actions.st+=/malefic_grasp,if=dot.unstable_affliction.ticking&dot.agony.ticking&dot.corruption.ticking
-actions.st+=/malefic_grasp,if=dot.unstable_affliction.ticking&dot.agony.ticking
-actions.st+=/shadow_bolt
-
-## AoE Rotation (5+ targets)
-actions.aoe+=/life_tap,if=mana.pct<40
-actions.aoe+=/agony,cycle_targets=1,if=target!=focus&remains<tick_time
-actions.aoe+=/corruption,cycle_targets=1,if=target!=focus&remains<tick_time
-actions.aoe+=/soulburn,if=talent.soulburn_seed_of_corruption.enabled&!buff.soulburn.up
-actions.aoe+=/seed_of_corruption,cycle_targets=1,if=!ticking&(active_enemies>3|buff.soulburn.up)
-actions.aoe+=/haunt,if=!ticking&soul_shards>=1
-actions.aoe+=/malefic_grasp,if=dot.unstable_affliction.ticking&dot.agony.ticking&dot.corruption.ticking
-actions.aoe+=/shadow_bolt
-
-## Movement Rotation
-actions.move+=/life_tap,if=mana.pct<40
-actions.move+=/agony,if=remains<tick_time
-actions.move+=/corruption,if=remains<tick_time
-actions.move+=/fel_flame,if=talent.kiljaedens_cunning.enabled
-actions.move+=/drain_life,if=talent.kiljaedens_cunning.enabled
-actions.move+=/fel_flame
+actions.aoe=summon_infernal
+actions.aoe+=/soulburn,cycle_targets=1,if=buff.soulburn.down&!dot.soulburn_seed_of_corruption.ticking&!action.soulburn_seed_of_corruption.in_flight_to_target&soul_shards>0
+actions.aoe+=/soul_swap,if=buff.soulburn.up&!dot.agony.ticking&!dot.corruption.ticking
+actions.aoe+=/soul_swap,cycle_targets=1,if=buff.soulburn.up&dot.corruption.ticking&!dot.agony.ticking
+actions.aoe+=/seed_of_corruption,cycle_targets=1,if=(buff.soulburn.down&!in_flight_to_target&!ticking)|(buff.soulburn.up&!dot.soulburn_seed_of_corruption.ticking&!action.soulburn_seed_of_corruption.in_flight_to_target)
+actions.aoe+=/haunt,cycle_targets=1,if=!in_flight_to_target&debuff.haunt.remains<cast_time+travel_time&soul_shards>0
+actions.aoe+=/life_tap,if=mana.pct<70
+actions.aoe+=/fel_flame,cycle_targets=1,if=!in_flight_to_target

--- a/MistsOfPandaria/WarlockAffliction.lua
+++ b/MistsOfPandaria/WarlockAffliction.lua
@@ -1,5 +1,5 @@
 -- WarlockAffliction.lua
--- Updated May 30, 2025 
+-- Updated Sep 28, 2025
 
 
 -- MoP: Use UnitClass instead of UnitClassBase
@@ -19,6 +19,13 @@ end
 local strformat = string.format
 local FindUnitBuffByID, FindUnitDebuffByID = ns.FindUnitBuffByID, ns.FindUnitDebuffByID
 
+-- Cache global API references to avoid environment issues during emulation/state generation
+local _GetSpellCritChance = ( _G and type( _G.GetSpellCritChance ) == "function" ) and _G.GetSpellCritChance or nil
+local _GetSpellBonusDamage = ( _G and type( _G.GetSpellBonusDamage ) == "function" ) and _G.GetSpellBonusDamage or nil
+local _UnitStat = ( _G and type( _G.UnitStat ) == "function" ) and _G.UnitStat or nil
+local _UnitSpellHaste = ( _G and type( _G.UnitSpellHaste ) == "function" ) and _G.UnitSpellHaste or nil
+local _GetMastery = ( _G and type( _G.GetMastery ) == "function" ) and _G.GetMastery or nil
+
 -- Enhanced helper functions for Affliction Warlock
 local function GetTargetDebuffByID(spellID)
     return FindUnitDebuffByID("target", spellID, "PLAYER")
@@ -31,6 +38,7 @@ local spec = Hekili:NewSpecialization( 265 ) -- Affliction spec ID for MoP
 -- Affliction-specific combat log event tracking
 local afflictionCombatLogFrame = CreateFrame("Frame")
 local afflictionCombatLogEvents = {}
+local hauntFlight = { active = false, destGUID = nil, expires = 0 }
 
 local function RegisterAfflictionCombatLogEvent(event, handler)
     if not afflictionCombatLogEvents[event] then
@@ -42,7 +50,7 @@ end
 afflictionCombatLogFrame:SetScript("OnEvent", function(self, event, ...)
     if event == "COMBAT_LOG_EVENT_UNFILTERED" then
         local timestamp, subevent, _, sourceGUID, sourceName, sourceFlags, sourceRaidFlags, destGUID, destName, destFlags, destRaidFlags = CombatLogGetCurrentEventInfo()
-        
+
         if sourceGUID == UnitGUID("player") then
             local handlers = afflictionCombatLogEvents[subevent]
             if handlers then
@@ -51,10 +59,16 @@ afflictionCombatLogFrame:SetScript("OnEvent", function(self, event, ...)
                 end
             end
         end
+    elseif event == "PLAYER_TARGET_CHANGED" then
+        dot_snapshot.agony.value = 0; dot_snapshot.agony.crit = 0
+        dot_snapshot.corruption.value = 0; dot_snapshot.corruption.crit = 0
+        dot_snapshot.unstable_affliction.value = 0; dot_snapshot.unstable_affliction.crit = 0
+        hauntFlight.active = false; hauntFlight.destGUID = nil; hauntFlight.expires = 0
     end
 end)
 
 afflictionCombatLogFrame:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED")
+afflictionCombatLogFrame:RegisterEvent("PLAYER_TARGET_CHANGED")
 
 -- Provide safe state expression shims so loader doesn't warn before events populate these.
 spec:RegisterStateExpr( "last_dot_tick", function()
@@ -80,14 +94,17 @@ spec:RegisterStateExpr( "tick_time", function()
     return 0
 end )
 
--- (Do not alias soul_shards; let the resource table exist at state.soul_shards for APL access.)
+-- Planned DoT casts within a single recommendation build (prevents duplicate DoT spam in queue)
+spec:RegisterStateTable( "planned_dot", setmetatable( {}, { __index = function() return false end } ) )
 
--- Pet management system for Affliction Warlock
-local function summon_demon(demon_type)
-    -- Track which demon is active
-    -- Note: These state changes only work within ability handlers
-    -- This function is for reference/documentation purposes
-end
+-- Clear planned DoTs at the beginning of each recommendation build
+spec:RegisterHook( "reset_precast", function ()
+    if state.planned_dot then
+        for k in pairs( state.planned_dot ) do
+            state.planned_dot[ k ] = nil
+        end
+    end
+end )
 
 -- Pet stat tracking
 local function update_pet_stats()
@@ -101,21 +118,29 @@ spec:RegisterStateExpr("pet_health_pct", function()
     return state.pet_health_pct or 0
 end)
 
--- DoT snapshot tracking for percent_increase logic (now after spec and RegisterAfflictionCombatLogEvent)
+-- Haunt projectile in-flight tracking
+spec:RegisterStateExpr( "haunt_in_flight", function()
+    if not hauntFlight.active then return 0 end
+    if hauntFlight.destGUID ~= UnitGUID("target") then return 0 end
+    local now = state.query_time or GetTime()
+    return (hauntFlight.expires > now) and 1 or 0
+end )
+
+-- DoT snapshot tracking for percent_increase logic
 local dot_snapshot = {
-    agony = { value = 0 },
-    corruption = { value = 0 },
-    unstable_affliction = { value = 0 },
+    agony = { value = 0, crit = 0 },
+    corruption = { value = 0, crit = 0 },
+    unstable_affliction = { value = 0, crit = 0 },
 }
 
 -- Helper to get current snapshot value (spell power + haste + mastery)
 local function get_dot_snapshot_value()
-    -- MoP: Use UnitStat for spell power (stat 5 = Intellect)
-    local spell_power = select(2, UnitStat("player", 5)) or 0
-    local haste = UnitSpellHaste and UnitSpellHaste("player") or 0
-    local mastery = GetMastery and GetMastery() or 0
-    -- Weighted sum, adjust as needed for MoP
-    return spell_power + haste + mastery
+    local sp = ( _GetSpellBonusDamage and _GetSpellBonusDamage( 6 ) ) or 0
+    local crit = ( _GetSpellCritChance and _GetSpellCritChance( 6 ) ) or 0
+    local mastery = ( _GetMastery and _GetMastery() ) or 0
+    local critMult = 1 + ( crit / 100 )
+    local mastMult = 1 + ( mastery / 100 )
+    return sp * critMult * mastMult
 end
 
 -- Calculate percent increase for a DoT
@@ -123,7 +148,7 @@ local function get_dot_percent_increase(dot)
     local last = dot_snapshot[dot] and dot_snapshot[dot].value or 0
     local current = get_dot_snapshot_value()
     if last == 0 then return 0 end
-    return math.floor((current - last) / last * 100)
+    return math.floor(((current - last) / last) * 100)
 end
 
 -- Register state expressions for percent_increase with safe aura access
@@ -135,6 +160,40 @@ for _, dot in ipairs({"agony", "corruption", "unstable_affliction"}) do
             return get_dot_percent_increase(dot)
         end
         return 0
+    end)
+end
+
+-- Provide accurate ticks_remain for DoTs from predicted/live aura
+for _, dot in ipairs({"agony", "corruption", "unstable_affliction"}) do
+    spec:RegisterStateExpr("dot." .. dot .. ".ticks_remain", function()
+        local now = state.query_time or GetTime()
+        local aura_table = state.debuff and state.debuff[dot]
+
+        local expires
+        if aura_table and (aura_table.expires or 0) > now then
+            expires = aura_table.expires
+        else
+            -- Fallback to live aura
+            local spellId = (dot == "agony" and 980) or (dot == "corruption" and 146739) or (dot == "unstable_affliction" and 30108)
+            local name, _, _, _, duration, expirationTime, caster = GetTargetDebuffByID( spellId )
+            if name and caster == "player" and (expirationTime or 0) > now then
+                expires = expirationTime
+            else
+                return 0
+            end
+        end
+
+        local remains = math.max(0, (expires or 0) - now)
+        local tick = (dot == "agony" or dot == "unstable_affliction") and 2 or 3
+        return remains / tick
+    end)
+end
+
+-- Provide crit percentage per-dot
+for _, dot in ipairs({"agony", "corruption", "unstable_affliction"}) do
+    spec:RegisterStateExpr("dot." .. dot .. ".crit_pct", function()
+        local crit = ( _GetSpellCritChance and _GetSpellCritChance( 6 ) ) or 0
+        return crit
     end)
 end
 
@@ -167,11 +226,36 @@ local dot_spell_ids = {
     unstable_affliction = 30108, -- Unstable Affliction
 }
 
-RegisterAfflictionCombatLogEvent("SPELL_AURA_APPLIED", function(_, _, _, _, _, _, _, destName, _, _, _, spellID)
+RegisterAfflictionCombatLogEvent("SPELL_AURA_APPLIED", function(timestamp, subevent, sourceGUID, sourceName, sourceFlags, sourceRaidFlags, destGUID, destName, destFlags, destRaidFlags, spellID)
     for dot, id in pairs(dot_spell_ids) do
-        if spellID == id and destName == UnitName("target") then
+        if spellID == id and destGUID == UnitGUID("target") then
             dot_snapshot[dot].value = get_dot_snapshot_value()
+            dot_snapshot[dot].crit = ( _GetSpellCritChance and _GetSpellCritChance( 6 ) ) or 0
         end
+    end
+end)
+
+-- Also update snapshots on refresh events.
+RegisterAfflictionCombatLogEvent("SPELL_AURA_REFRESH", function(timestamp, subevent, sourceGUID, sourceName, sourceFlags, sourceRaidFlags, destGUID, destName, destFlags, destRaidFlags, spellID)
+    for dot, id in pairs(dot_spell_ids) do
+        if spellID == id and destGUID == UnitGUID("target") then
+            dot_snapshot[dot].value = get_dot_snapshot_value()
+            dot_snapshot[dot].crit = ( _GetSpellCritChance and _GetSpellCritChance( 6 ) ) or 0
+        end
+    end
+end)
+
+-- Clear snapshots if the DoT is removed from the current target
+RegisterAfflictionCombatLogEvent("SPELL_AURA_REMOVED", function(timestamp, subevent, sourceGUID, sourceName, sourceFlags, sourceRaidFlags, destGUID, destName, destFlags, destRaidFlags, spellID)
+    for dot, id in pairs(dot_spell_ids) do
+        if spellID == id and destGUID == UnitGUID("target") then
+            dot_snapshot[dot].value = 0
+            dot_snapshot[dot].crit = 0
+        end
+    end
+    if spellID == 48181 and hauntFlight.active and hauntFlight.destGUID == destGUID then
+        hauntFlight.active = false
+        hauntFlight.expires = 0
     end
 end)
 
@@ -182,7 +266,10 @@ RegisterAfflictionCombatLogEvent("SPELL_CAST_SUCCESS", function(timestamp, subev
     elseif spellID == 1120 then -- Drain Soul
         -- Drain Soul generates Soul Shards when target dies
     elseif spellID == 48181 then -- Haunt
-        -- Haunt generates a Soul Shard when it fades
+        -- Mark Haunt as in-flight until it applies (or short timeout)
+        hauntFlight.active = true
+        hauntFlight.destGUID = destGUID
+        hauntFlight.expires = ( state.query_time or GetTime() ) + 0.6
     end
 end)
 
@@ -212,8 +299,11 @@ RegisterAfflictionCombatLogEvent("SPELL_AURA_APPLIED", function(timestamp, subev
         -- Agony application (stack building handled in aura system elsewhere)
         -- Ensure internal tracking starts
     elseif spellID == 48181 then -- Haunt
-        -- Track Haunt application for Soul Shard generation
-        -- Note: Haunt tracking handled by default aura system
+        -- Clear in-flight on application
+        if hauntFlight.active and hauntFlight.destGUID == destGUID then
+            hauntFlight.active = false
+            hauntFlight.expires = 0
+        end
     end
 end)
 
@@ -274,7 +364,7 @@ spec:RegisterResource( 7, {
             return shards_generated
         end,
     },
-    
+
     -- Drain Soul generation when target dies
     drain_soul_death = {
         last = function ()
@@ -282,22 +372,9 @@ spec:RegisterResource( 7, {
         end,
         interval = 1,
         value = function()
-            -- Drain Soul generates 1 Soul Shard when target dies
+            -- Drain Soul generates 4 Soul Shards when target dies
             local la = rawget( state, "last_ability" )
-            return ( la == "drain_soul" ) and state.target_died and 1 or 0
-        end,
-    },
-    
-    -- Haunt Soul Shard generation
-    haunt_generation = {
-        last = function ()
-            return state.last_cast_time.haunt or 0
-        end,
-        interval = 1,
-        value = function()
-            -- Haunt generates 1 Soul Shard when it fades
-            local la = rawget( state, "last_ability" )
-            return ( la == "haunt" ) and 1 or 0
+            return ( la == "drain_soul" ) and state.target_died and 4 or 0
         end,
     },
 }, {
@@ -305,7 +382,7 @@ spec:RegisterResource( 7, {
     nightfall_bonus = function ()
         return state.talent.nightfall.enabled and 0.1 or 0 -- 10% bonus from Nightfall
     end,
-    
+
     soul_harvest_bonus = function ()
         return state.talent.soul_harvest.enabled and 0.2 or 0 -- 20% bonus from Soul Harvest
     end,
@@ -476,7 +553,7 @@ spec:RegisterGlyphs( {
     [56226] = "soul_swap",              -- Soul Swap can now affect up to 2 additional nearby targets when used on a target with Corruption, Agony, and Unstable Affliction.
     [56248] = "unstable_affliction",    -- Unstable Affliction can be applied to 3 targets, but its damage is reduced by 25%.
     [63320] = "voidwalker",            -- Increases your Voidwalker's health by 30% and its Taunt now affects up to 3 enemies.
-    
+
     -- Major Glyphs - Resource Management
     [56233] = "demon_training",         -- Your demons deal 10% more damage and take 10% less damage.
     [70947] = "eternal_resolve",        -- Reduces the cooldown of Unending Resolve by 60 sec.
@@ -486,7 +563,7 @@ spec:RegisterGlyphs( {
     [58054] = "burning_rush",           -- Burning Rush increases movement speed by an additional 20% but the health cost is increased by 2%.
     [56239] = "harvest_life",           -- Harvest Life affects 2 additional targets and heals you for 50% more.
     [58079] = "sacrificial_pact",       -- Reduces the cooldown of Sacrificial Pact by 60 sec and increases its absorption by 50%.
-    
+
     -- Major Glyphs - Utility Enhancement
     [56224] = "banish",                 -- Increases the duration of your Banish by 5 sec and allows it to be used on Aberrations.
     [56231] = "create_healthstone",     -- You can have up to 5 Healthstones in your bags, and creating them grants you one immediately.
@@ -495,7 +572,7 @@ spec:RegisterGlyphs( {
     [56213] = "enslave_demon",          -- Reduces the cast time of Enslave Demon by 50% and its duration is increased by 10 sec.
     [56223] = "eye_of_kilrogg",         -- Increases the movement speed of your Eye of Kilrogg by 50% and extends its duration by 45 sec.
     [56217] = "unending_breath",        -- Your Unending Breath spell also grants water breathing and increases swim speed by 50%.
-    
+
     -- Minor Glyphs - Visual and Convenience
     [58081] = "verdant_spheres",        -- Your Soul Shards appear as green orbs instead of purple.
     [63310] = "soul_stone",             -- Reduces the mana cost of your Soulstone by 50%.
@@ -535,27 +612,55 @@ spec:RegisterAuras( {
         debuff = true,
         pandemic = true,
         generate = function( t )
-            local name, icon, count, debuffType, duration, expirationTime, caster = GetTargetDebuffByID( 146739 )
-            if name and caster == "player" then
-                t.name = name
-                t.count = 1
-                t.expires = expirationTime
-                t.applied = expirationTime - duration
-                t.caster = caster
-                t.duration = duration
+            local now = state.query_time or GetTime()
+            local p = state.debuff and state.debuff.corruption
+
+            if p and (p.applied or 0) > 0 then
+                t.name = "Corruption"
+                t.count = (p.count and p.count > 0) and p.count or 1
+                t.expires = p.expires or 0
+                t.applied = p.applied or 0
+                t.duration = math.max( 0, (t.expires or 0) - (t.applied or 0) )
+                t.caster = "player"
             else
-                t.count = 0
-                t.expires = 0
-                t.applied = 0
-                t.caster = "nobody"
-                t.duration = 18
+                -- Fallback to live aura if no prediction is present.
+                local name, icon, count, debuffType, duration, expirationTime, caster = GetTargetDebuffByID( 146739 )
+                if name and caster == "player" then
+                    t.name = name
+                    t.count = 1
+                    t.expires = expirationTime
+                    t.applied = expirationTime - duration
+                    t.caster = caster
+                    t.duration = duration
+                else
+                    t.count = 0
+                    t.expires = 0
+                    t.applied = 0
+                    t.caster = "nobody"
+                    t.duration = 18
+                end
             end
+
             -- Derived helpers for APL compatibility
             t.percent_increase = get_dot_percent_increase("corruption") or 0
-            t.refreshable = (t.expires - (state.query_time or GetTime())) <= (t.duration * 0.3)
+            t.snapshot_value = ( dot_snapshot.corruption and dot_snapshot.corruption.value ) or 0
+            t.crit_pct = ( _GetSpellCritChance and _GetSpellCritChance( 6 ) ) or 0
+
+            -- Calculate ticks_remain and refreshable with level-appropriate pandemic mechanics
+            local remains = math.max(0, (t.expires or 0) - now)
+            t.ticks_remain = remains / 3
+
+            local has_pandemic = UnitLevel("player") >= 90
+            local pandemic_threshold = (t.duration or 18) * (has_pandemic and 0.5 or 0.1)
+
+            if t.expires > 0 and t.expires > now then
+                t.refreshable = remains <= pandemic_threshold
+            else
+                t.refreshable = true
+            end
         end,
     },
-    
+
     agony = {
         id = 980,
         duration = 24,
@@ -564,27 +669,53 @@ spec:RegisterAuras( {
         debuff = true,
         pandemic = true,
         generate = function( t )
-            local name, icon, count, debuffType, duration, expirationTime, caster = GetTargetDebuffByID( 980 )
-            if name and caster == "player" then
-                t.name = name
-                t.count = count or 1
-                t.expires = expirationTime
-                t.applied = expirationTime - duration
-                t.caster = caster
-                t.duration = duration
+            local now = state.query_time or GetTime()
+            local p = state.debuff and state.debuff.agony
+
+            if p and (p.applied or 0) > 0 then
+                t.name = "Agony"
+                t.count = (p.count and p.count > 0) and p.count or 1
+                t.expires = p.expires or 0
+                t.applied = p.applied or 0
+                t.duration = math.max( 0, (t.expires or 0) - (t.applied or 0) )
+                t.caster = "player"
             else
-                t.count = 0
-                t.expires = 0
-                t.applied = 0
-                t.caster = "nobody"
-                t.duration = 24
+                local name, icon, count, debuffType, duration, expirationTime, caster = GetTargetDebuffByID( 980 )
+                if name and caster == "player" then
+                    t.name = name
+                    t.count = count or 1
+                    t.expires = expirationTime
+                    t.applied = expirationTime - duration
+                    t.caster = caster
+                    t.duration = duration
+                else
+                    t.count = 0
+                    t.expires = 0
+                    t.applied = 0
+                    t.caster = "nobody"
+                    t.duration = 24
+                end
             end
             -- Derived helpers for APL compatibility
             t.percent_increase = get_dot_percent_increase("agony") or 0
-            t.refreshable = (t.expires - (state.query_time or GetTime())) <= (t.duration * 0.3)
+            t.snapshot_value = ( dot_snapshot.agony and dot_snapshot.agony.value ) or 0
+            t.crit_pct = ( _GetSpellCritChance and _GetSpellCritChance( 6 ) ) or 0
+
+            -- Calculate ticks_remain and refreshable with level-appropriate pandemic mechanics
+            local remains = math.max(0, (t.expires or 0) - now)
+            t.ticks_remain = remains / 2
+
+            local has_pandemic = UnitLevel("player") >= 90
+            local pandemic_threshold = (t.duration or 24) * (has_pandemic and 0.5 or 0.1)
+
+            if t.expires > 0 and t.expires > now then
+                t.refreshable = remains <= pandemic_threshold
+            else
+                t.refreshable = true
+            end
         end,
     },
-    
+
     unstable_affliction = {
         id = 30108,
         duration = 14,
@@ -593,24 +724,50 @@ spec:RegisterAuras( {
         debuff = true,
         pandemic = true,
         generate = function( t )
-            local name, icon, count, debuffType, duration, expirationTime, caster = GetTargetDebuffByID( 30108 )
-            if name and caster == "player" then
-                t.name = name
+            local now = state.query_time or GetTime()
+            local p = state.debuff and state.debuff.unstable_affliction
+
+            if p and (p.applied or 0) > 0 then
+                t.name = "Unstable Affliction"
                 t.count = 1
-                t.expires = expirationTime
-                t.applied = expirationTime - duration
-                t.caster = caster
-                t.duration = duration
+                t.expires = p.expires or 0
+                t.applied = p.applied or 0
+                t.duration = math.max( 0, (t.expires or 0) - (t.applied or 0) )
+                t.caster = "player"
             else
-                t.count = 0
-                t.expires = 0
-                t.applied = 0
-                t.caster = "nobody"
-                t.duration = 14
+                local name, icon, count, debuffType, duration, expirationTime, caster = GetTargetDebuffByID( 30108 )
+                if name and caster == "player" then
+                    t.name = name
+                    t.count = 1
+                    t.expires = expirationTime
+                    t.applied = expirationTime - duration
+                    t.caster = caster
+                    t.duration = duration
+                else
+                    t.count = 0
+                    t.expires = 0
+                    t.applied = 0
+                    t.caster = "nobody"
+                    t.duration = 14
+                end
             end
             -- Derived helpers for APL compatibility
             t.percent_increase = get_dot_percent_increase("unstable_affliction") or 0
-            t.refreshable = (t.expires - (state.query_time or GetTime())) <= (t.duration * 0.3)
+            t.snapshot_value = ( dot_snapshot.unstable_affliction and dot_snapshot.unstable_affliction.value ) or 0
+            t.crit_pct = ( _GetSpellCritChance and _GetSpellCritChance( 6 ) ) or 0
+
+            -- Calculate ticks_remain and refreshable with level-appropriate pandemic mechanics
+            local remains = math.max(0, (t.expires or 0) - now)
+            t.ticks_remain = remains / 2
+
+            local has_pandemic = UnitLevel("player") >= 90
+            local pandemic_threshold = (t.duration or 14) * (has_pandemic and 0.5 or 0.1)
+
+            if t.expires > 0 and t.expires > now then
+                t.refreshable = remains <= pandemic_threshold
+            else
+                t.refreshable = true
+            end
         end,
     },
 
@@ -620,33 +777,35 @@ spec:RegisterAuras( {
         max_stack = 1,
         debuff = true,
     },
-    
-    curse_of_elements = {
-        id = 1490,
-        duration = 300,
-        max_stack = 1,
-        debuff = true,
-        generate = function( t )
-            local name, icon, count, debuffType, duration, expirationTime, caster = GetTargetDebuffByID( 1490 )
-            
-            if name and caster == "player" then
-                t.name = name
-                t.count = 1
-                t.expires = expirationTime
-                t.applied = expirationTime - duration
-                t.caster = caster
-                t.duration = duration
-                return
-            end
-            
-            t.count = 0
-            t.expires = 0
-            t.applied = 0
-            t.caster = "nobody"
-            t.duration = 300
-        end,
-    },
-    
+
+    -- Moved to ./Classes.lua, use magic_vulnerability instead
+    -- curse_of_elements = {
+    --     id = 1490,
+    --     duration = 300,
+    --     max_stack = 1,
+    --     debuff = true,
+    --     generate = function( t )
+    --         local name, icon, count, debuffType, duration, expirationTime, caster = GetTargetDebuffByID( 1490 )
+
+    --         if name and caster == "player" then
+    --             t.name = name
+    --             t.count = 1
+    --             t.expires = expirationTime
+    --             t.applied = expirationTime - duration
+    --             t.caster = caster
+    --             t.duration = duration
+    --             return
+    --         end
+
+    --         t.count = 0
+    --         t.expires = 0
+    --         t.applied = 0
+    --         t.caster = "nobody"
+    --         t.duration = 300
+    --         return
+    --     end,
+    -- },
+
     seed_of_corruption = {
         id = 27243,
         duration = 18,
@@ -655,7 +814,7 @@ spec:RegisterAuras( {
         debuff = true,
         generate = function( t )
             local name, icon, count, debuffType, duration, expirationTime, caster = GetTargetDebuffByID( 27243 )
-            
+
             if name and caster == "player" then
                 t.name = name
                 t.count = 1
@@ -665,41 +824,70 @@ spec:RegisterAuras( {
                 t.duration = duration
                 return
             end
-            
+
             t.count = 0
             t.expires = 0
             t.applied = 0
             t.caster = "nobody"
             t.duration = 18
+            return
         end,
     },
-    
+
+    soulburn_seed_of_corruption = {
+        id = 114790,
+        duration = 18,
+        max_stack = 1,
+        debuff = true,
+
+        generate = function( t )
+            local name, icon, count, debuffType, duration, expirationTime, caster = GetTargetDebuffByID( 114790 )
+
+            if name and caster == "player" then
+                t.name = name
+                t.count = 1
+                t.expires = expirationTime
+                t.applied = expirationTime - duration
+                t.caster = caster
+                t.duration = duration
+                return
+            end
+
+            t.count = 0
+            t.expires = 0
+            t.applied = 0
+            t.caster = "nobody"
+            t.duration = 18
+            return
+        end,
+    },
+
     -- Player buffs (using default aura tracking)
     nightfall = {
         id = 17941,
         duration = 12,
         max_stack = 1,
     },
-    
+
     soul_burn = {
         id = 74434,
         duration = 30,
         max_stack = 1,
     },
-    
+
     -- Dark Soul forms with enhanced tracking
     dark_soul_knowledge = {
         id = 113858,
         duration = 20,
         max_stack = 1,
     },
-    
+
     dark_soul_misery = {
         id = 113860,
         duration = 20,
         max_stack = 1,
     },
-    
+
     -- Channeled abilities
     malefic_grasp = {
         id = 103103,
@@ -709,7 +897,7 @@ spec:RegisterAuras( {
         debuff = true,
         generate = function( t )
             local name, icon, count, debuffType, duration, expirationTime, caster = GetTargetDebuffByID( 103103 )
-            
+
             if name and caster == "player" then
                 t.name = name
                 t.count = 1
@@ -719,7 +907,7 @@ spec:RegisterAuras( {
                 t.duration = duration
                 return
             end
-            
+
             t.count = 0
             t.expires = 0
             t.applied = 0
@@ -727,7 +915,7 @@ spec:RegisterAuras( {
             t.duration = 3
         end,
     },
-    
+
     drain_soul = {
         id = 1120,
         duration = 6,
@@ -736,7 +924,7 @@ spec:RegisterAuras( {
         debuff = true,
         generate = function( t )
             local name, icon, count, debuffType, duration, expirationTime, caster = GetTargetDebuffByID( 1120 )
-            
+
             if name and caster == "player" then
                 t.name = name
                 t.count = 1
@@ -746,7 +934,7 @@ spec:RegisterAuras( {
                 t.duration = duration
                 return
             end
-            
+
             t.count = 0
             t.expires = 0
             t.applied = 0
@@ -754,122 +942,122 @@ spec:RegisterAuras( {
             t.duration = 6
         end,
     },
-    
+
     -- Defensive and utility auras (using default tracking)
     unending_resolve = {
         id = 104773,
         duration = 8,
         max_stack = 1,
     },
-    
+
     dark_bargain = {
         id = 110913,
         duration = 8,
         max_stack = 1,
     },
-    
+
     sacrificial_pact = {
         id = 108416,
         duration = 8,
         max_stack = 1,
     },
-    
+
     -- Movement and utility
     burning_rush = {
         id = 111400,
         duration = 3600,
         max_stack = 1,
     },
-    
+
     unbound_will = {
         id = 108482,
         duration = 6,
         max_stack = 1,
     },
-    
+
     -- Armor buffs
     fel_armor = {
         id = 28176,
         duration = 1800,
         max_stack = 1,
     },
-    
+
     demon_armor = {
         id = 687,
         duration = 1800,
         max_stack = 1,
     },
-    
+
     -- Talent-based auras
     soul_link = {
         id = 108415,
         duration = 3600,
         max_stack = 1,
     },
-    
+
     grimoire_of_sacrifice = {
         id = 108503,
         duration = 15,
         max_stack = 1,
     },
-    
+
     -- Tier set bonuses (using default tracking)
     tier14_2pc_affliction = {
         id = 105843,
         duration = 30,
         max_stack = 1,
     },
-    
+
     tier14_4pc_affliction = {
         id = 105844,
         duration = 8,
         max_stack = 1,
     },
-    
+
     tier15_2pc_affliction = {
         id = 138129,
         duration = 15,
         max_stack = 1,
     },
-    
+
     tier15_4pc_affliction = {
         id = 138132,
         duration = 6,
         max_stack = 1,
     },
-    
+
     tier16_2pc_affliction = {
         id = 144912,
         duration = 20,
         max_stack = 1,
     },
-    
+
     tier16_4pc_affliction = {
         id = 144915,
         duration = 8,
         max_stack = 3,
     },
-    
+
     -- Legendary cloak proc
     legendary_cloak_proc = {
         id = 148009,
         duration = 4,
         max_stack = 1,
     },
-    
+
     -- Missing auras referenced in action lists (using default tracking)
     dark_soul = {
         id = 113860,
         duration = 20,
         max_stack = 1,
     },
-    
+
     soulburn = {
         id = 74434,
         duration = 30,
         max_stack = 1,
     },
-    
+
     haunting_spirits = {
         id = 157698, -- Custom tracking ID
         duration = 8,
@@ -877,7 +1065,7 @@ spec:RegisterAuras( {
         generate = function( t )
             -- This is typically generated from Haunt expiration
             local haunt_expired = state.debuff.haunt.remains == 0 and state.debuff.haunt.applied > 0
-            
+
             if haunt_expired then
                 t.name = "Haunting Spirits"
                 t.count = 1
@@ -886,14 +1074,14 @@ spec:RegisterAuras( {
                 t.caster = "player"
                 return
             end
-            
+
             t.count = 0
             t.expires = 0
             t.applied = 0
             t.caster = "nobody"
         end,
     },
-    
+
     drain_life = {
         id = 689,
         duration = 5,
@@ -902,7 +1090,7 @@ spec:RegisterAuras( {
         debuff = true,
         generate = function( t )
             local name, icon, count, debuffType, duration, expirationTime, caster = GetTargetDebuffByID( 689 )
-            
+
             if name and caster == "player" then
                 t.name = name
                 t.count = 1
@@ -912,7 +1100,7 @@ spec:RegisterAuras( {
                 t.duration = duration
                 return
             end
-            
+
             t.count = 0
             t.expires = 0
             t.applied = 0
@@ -920,14 +1108,14 @@ spec:RegisterAuras( {
             t.duration = 5
         end,
     },
-    
+
     soul_swap = {
         id = 86211,
         duration = 20,
         max_stack = 1,
-        
+
     },
-    
+
     soul_swap_exhale = {
         id = 86213,
         duration = 0.1, -- Very short duration, just for state tracking
@@ -942,14 +1130,14 @@ spec:RegisterAuras( {
                 t.caster = "player"
                 return
             end
-            
+
             t.count = 0
             t.expires = 0
             t.applied = 0
             t.caster = "nobody"
         end,
     },
-    
+
     -- Dark Intent aura
     dark_intent = {
         id = 109773,
@@ -966,114 +1154,139 @@ spec:RegisterAbilities( {
         cast = function() return 1.5 * haste end,
         cooldown = 8,
         gcd = "spell",
-        
+
         spend = 1,
         spendType = "soul_shards",
-        
+
         startsCombat = true,
         texture = 236298,
-        
+
     handler = function() applyDebuff( "target", "haunt" ) end,
     },
-    
+
     agony = {
         id = 980,
         cast = 0,
         cooldown = 0,
         gcd = "spell",
-        
+
         spend = 0.1,
         spendType = "mana",
-        
+
         startsCombat = true,
         texture = 136139,
-        
+
         aura = "agony",
-        
+
+        usable = function()
+            if state.planned_dot and state.planned_dot.agony then return false, "agony already planned" end
+            return true
+        end,
+
         handler = function()
             applyDebuff( "target", "agony" )
+            state.last_ability = "agony"
+            dot_snapshot.agony.value = get_dot_snapshot_value()
+            dot_snapshot.agony.crit = ( _GetSpellCritChance and _GetSpellCritChance( 6 ) ) or 0
+            if state.planned_dot then state.planned_dot.agony = true end
         end,
     },
-    
+
     corruption = {
         id = 172,
         cast = 0,
         cooldown = 0,
         gcd = "spell",
-        
+
         spend = 0.1,
         spendType = "mana",
-        
+
         startsCombat = true,
         texture = 136118,
-        
+
         aura = "corruption",
-        
+
+        usable = function()
+            if state.planned_dot and state.planned_dot.corruption then return false, "corruption already planned" end
+            return true
+        end,
+
         handler = function()
             applyDebuff( "target", "corruption" )
+            state.last_ability = "corruption"
+            dot_snapshot.corruption.value = get_dot_snapshot_value()
+            dot_snapshot.corruption.crit = ( _GetSpellCritChance and _GetSpellCritChance( 6 ) ) or 0
+            if state.planned_dot then state.planned_dot.corruption = true end
         end,
     },
-    
-    cast_unstable_affliction = {
+
+    unstable_affliction = {
         id = 30108,
-        cast = function() return 1.5 * haste end,
+        cast = 1.5,
         cooldown = 0,
         gcd = "spell",
-        
+
         spend = 0.15,
         spendType = "mana",
-        
+
         startsCombat = true,
         texture = 136228,
-        
-        aura = "unstable_affliction",
-        
+
+        usable = function()
+            if state.planned_dot and state.planned_dot.unstable_affliction then return false, "unstable_affliction already planned" end
+            return true
+        end,
+
         handler = function()
             applyDebuff( "target", "unstable_affliction" )
+            state.last_ability = "unstable_affliction"
+            dot_snapshot.unstable_affliction.value = get_dot_snapshot_value()
+            dot_snapshot.unstable_affliction.crit = ( _GetSpellCritChance and _GetSpellCritChance( 6 ) ) or 0
+            if state.planned_dot then state.planned_dot.unstable_affliction = true end
         end,
     },
-    
-    cast_malefic_grasp = {
+
+    malefic_grasp = {
         id = 103103,
         cast = function() return 3 * haste end,
         cooldown = 0,
         gcd = "spell",
-        
+
         channeled = true,
-        
+
         spend = 0.04, -- Per tick
         spendType = "mana",
-        
+
         startsCombat = true,
-        texture = 136217,
-        
+        texture = 236296,
+
         handler = function()
             applyDebuff( "target", "malefic_grasp" )
         end,
-        
+
         finish = function()
             removeDebuff( "target", "malefic_grasp" )
         end,
     },
-    
+
     drain_soul = {
         id = 1120,
         cast = function() return 6 * haste end,
         cooldown = 0,
         gcd = "spell",
-        
+
         channeled = true,
-        
+
         spend = 0.04, -- Per tick
         spendType = "mana",
-        
+
         startsCombat = true,
         texture = 136163,
-        
+
         handler = function()
             applyDebuff( "target", "drain_soul" )
         end,
-        
+
         finish = function()
             removeDebuff( "target", "drain_soul" )
             -- Target died while channeling?
@@ -1082,90 +1295,90 @@ spec:RegisterAbilities( {
             end
         end,
     },
-    
-    cast_seed_of_corruption = {
+
+    seed_of_corruption = {
         id = 27243,
         cast = function() return 2 * haste end,
         cooldown = 0,
         gcd = "spell",
-        
+
         spend = 0.15,
         spendType = "mana",
-        
+
         startsCombat = true,
         texture = 136193,
-        
+
         handler = function()
             applyDebuff( "target", "seed_of_corruption" )
         end,
     },
-    
+
     life_tap = {
         id = 1454,
         cast = 0,
         cooldown = 0,
         gcd = "spell",
-        
+
         startsCombat = false,
         texture = 136126,
-        
+
         handler = function()
             -- Costs 15% health, returns 15% mana
             local health_cost = health.max * 0.15
             local mana_return = mana.max * 0.15
-            
+
             spend( health_cost, "health" )
             gain( mana_return, "mana" )
         end,
     },
-    
+
     fear = {
         id = 5782,
         cast = function() return 1.5 * haste end,
         cooldown = function() return glyph.nightmares.enabled and 15 or 23 end,
         gcd = "spell",
-        
+
         spend = 0.05,
         spendType = "mana",
-        
+
         startsCombat = true,
         texture = 136183,
-        
+
         handler = function()
             applyDebuff( "target", "fear" )
         end,
     },
-    
+
     curse_of_elements = {
         id = 1490,
         cast = 0,
         cooldown = 0,
         gcd = "spell",
-        
+
         spend = 0.1,
         spendType = "mana",
-        
+
         startsCombat = true,
         texture = 136130,
-        
+
         handler = function()
             applyDebuff( "target", "curse_of_elements" )
         end,
     },
-    
+
     -- Soul Shards spenders
     soul_swap = {
         id = 86121,
         cast = 0,
         cooldown = function() return glyph.soul_swap.enabled and 0 or 30 end,
         gcd = "spell",
-        
+
         spend = function() return glyph.soul_swap.enabled and 1 or 0 end,
         spendType = "soul_shards",
-        
+
         startsCombat = false,
         texture = 460857,
-        
+
         usable = function()
             -- Check if there are DoTs on the target
             if not (debuff.agony.up or debuff.corruption.up or debuff.unstable_affliction.up) then
@@ -1173,11 +1386,11 @@ spec:RegisterAbilities( {
             end
             return true
         end,
-        
+
         handler = function()
             -- Store target's DoTs
             applyBuff( "soul_swap" )
-            
+
             -- Remove DoTs from target if not using Exhale
             if buff.soul_swap_exhale.down then
                 removeDebuff( "target", "agony" )
@@ -1185,44 +1398,46 @@ spec:RegisterAbilities( {
                 removeDebuff( "target", "unstable_affliction" )
             end
         end,
+
+        copy = { 119678 },
     },
-    
+
     soul_swap_exhale = {
         id = 86213,
         cast = 0,
         cooldown = 0,
         gcd = "spell",
-        
+
         startsCombat = true,
         texture = 460857,
-        
+
         usable = function()
             return buff.soul_swap.up, "soul_swap buff not active"
         end,
-        
+
         handler = function()
             -- Apply DoTs from Soul Swap to target
             applyDebuff( "target", "agony" )
             applyDebuff( "target", "corruption" )
             applyDebuff( "target", "unstable_affliction" )
-            
+
             removeBuff( "soul_swap" )
             applyBuff( "soul_swap_exhale" )
         end,
     },
-    
+
     -- Cooldowns
     dark_soul_misery = {
         id = 113860,
         cast = 0,
         cooldown = 120,
         gcd = "off",
-        
+
         toggle = "cooldowns",
-        
+
         startsCombat = false,
         texture = 463284,
-        
+
         handler = function()
             applyBuff( "dark_soul_misery" )
         end,
@@ -1245,189 +1460,204 @@ spec:RegisterAbilities( {
         end,
     },
 
-    
     summon_doomguard = {
         id = 18540,
         cast = 0,
         cooldown = 600,
         gcd = "spell",
-        
+
         toggle = "cooldowns",
-        
+
         spend = 1,
         spendType = "soul_shards",
-        
+
         startsCombat = false,
         texture = 615103,
-        
+
         handler = function()
-            -- Summon pet
+            -- Summon guardian
         end,
     },
-    
+
+    summon_terrorguard = {
+        id = 112927,
+        cast = 0,
+        cooldown = 600,
+        gcd = "spell",
+
+        toggle = "cooldowns",
+
+        spend = 1,
+        spendType = "soul_shards",
+
+        startsCombat = false,
+        texture = 615098,
+
+        handler = function()
+            -- Summon guardian
+        end,
+    },
+
     -- Defensive and Utility
     dark_bargain = {
         id = 110913,
         cast = 0,
         cooldown = 180,
         gcd = "off",
-        
+
         toggle = "defensives",
-        
+
         startsCombat = false,
         texture = 538038,
-        
+
         handler = function()
             applyBuff( "dark_bargain" )
         end,
     },
-    
+
     unending_resolve = {
         id = 104773,
         cast = 0,
         cooldown = 180,
         gcd = "off",
-        
+
         toggle = "defensives",
-        
+
         startsCombat = false,
         texture = 136150,
-        
+
         handler = function()
             applyBuff( "unending_resolve" )
         end,
     },
-    
+
     demonic_circle_summon = {
         id = 48018,
         cast = 0.5,
         cooldown = 0,
         gcd = "spell",
-        
+
         startsCombat = false,
         texture = 136126,
-        
+
         handler = function()
             applyBuff( "demonic_circle" )
         end,
     },
-    
+
     demonic_circle_teleport = {
         id = 48020,
         cast = 0,
         cooldown = 30,
         gcd = "spell",
-        
+
         startsCombat = false,
         texture = 607512,
-        
+
         handler = function()
             -- Teleport to circle
         end,
     },
-    
+
     -- Talent abilities
     howl_of_terror = {
         id = 5484,
         cast = 0,
         cooldown = 40,
         gcd = "spell",
-        
+
         spend = 0.1,
         spendType = "mana",
-        
+
         startsCombat = true,
         texture = 607510,
-        
+
         handler = function()
             -- Fear all enemies in 10 yards
         end,
     },
-    
+
     mortal_coil = {
         id = 6789,
         cast = 0,
         cooldown = 30,
         gcd = "spell",
-        
+
         spend = 0.06,
         spendType = "mana",
-        
+
         startsCombat = true,
         texture = 607514,
-        
+
         handler = function()
             -- Fear target and heal 11% of max health
             local heal_amount = health.max * 0.11
             gain( heal_amount, "health" )
         end,
     },
-    
+
     shadowfury = {
         id = 30283,
         cast = 0,
         cooldown = 30,
         gcd = "spell",
-        
+
         spend = 0.06,
         spendType = "mana",
-        
+
         startsCombat = true,
         texture = 457223,
-        
+
         handler = function()
             -- Stun all enemies in 8 yards
         end,
     },
-    
+
     grimoire_of_sacrifice = {
         id = 108503,
         cast = 0,
         cooldown = 30,
         gcd = "spell",
-        
+
         startsCombat = false,
         texture = 538443,
-        
+
         handler = function()
             applyBuff( "grimoire_of_sacrifice" )
         end,
     },
-    
-    -- Missing abilities referenced in action lists
+
     fel_flame = {
         id = 77799,
         cast = 0,
         cooldown = 0,
         gcd = "spell",
-        
+
         spend = 0.05,
         spendType = "mana",
-        
+
         startsCombat = true,
-        texture = 651447,
-        
+        texture = 135795,
+
         handler = function()
             -- Instant damage spell
         end,
     },
 
-    -- (removed legacy generic summon_pet; use explicit summons or alias below)
-    
     summon_infernal = {
         id = 1122,
         cast = 0,
         cooldown = 600,
         gcd = "spell",
-        
+
         toggle = "cooldowns",
-        
+
         spend = 1,
         spendType = "soul_shards",
-        
+
         startsCombat = false,
         texture = 136219,
-        
+
         handler = function()
             -- Summon infernal
         end,
@@ -1438,36 +1668,36 @@ spec:RegisterAbilities( {
         cast = function() return 5 * haste end,
         cooldown = 0,
         gcd = "spell",
-        
+
         channeled = true,
-        
-        spend = 0.04, -- Per tick
+
+        spend = 0.04, --Per tick
         spendType = "mana",
-        
+
         startsCombat = true,
         texture = 136169,
-        
+
         handler = function()
             applyDebuff( "target", "drain_life" )
         end,
-        
+
         finish = function()
             removeDebuff( "target", "drain_life" )
         end,
     },
-    
+
     soulburn = {
         id = 74434,
         cast = 0,
         cooldown = 0,
         gcd = "spell",
-        
+
         spend = 1,
         spendType = "soul_shards",
-        
+
         startsCombat = false,
         texture = 463286,
-        
+
         usable = function()
             if buff.soul_burn.up then return false, "soul burn active" end
             local shards = ( state.soul_shards and state.soul_shards.current ) or 0
@@ -1479,7 +1709,24 @@ spec:RegisterAbilities( {
             applyBuff( "soul_burn" )
         end,
     },
-    
+
+    soulburn_seed_of_corruption = {
+        id = 114790,
+        cast = 2,
+        cooldown = 0,
+        gcd = "spell",
+
+        spend = 0,
+        spendType = "soul_shards",
+
+        startsCombat = true,
+        texture = 136193,
+
+        handler = function()
+            applyDebuff( "target", "soulburn_seed_of_corruption" )
+        end,
+    },
+
     -- Summon demons (MoP: cost 1 Soul Shard, 6s cast)
     summon_imp = {
         id = 688,
@@ -1491,7 +1738,9 @@ spec:RegisterAbilities( {
         startsCombat = false,
         texture = 136218,
         handler = function()
-            -- Summon Imp
+            -- Emulate pet becoming active as soon as the summon is committed in the planner.
+            state.pet.alive = true
+            state.pet.family = "Imp"
         end,
     },
     summon_voidwalker = {
@@ -1504,7 +1753,8 @@ spec:RegisterAbilities( {
         startsCombat = false,
         texture = 136221,
         handler = function()
-            -- Summon Voidwalker
+            state.pet.alive = true
+            state.pet.family = "Voidwalker"
         end,
     },
     summon_succubus = {
@@ -1517,7 +1767,8 @@ spec:RegisterAbilities( {
         startsCombat = false,
         texture = 136220,
         handler = function()
-            -- Summon Succubus
+            state.pet.alive = true
+            state.pet.family = "Succubus"
         end,
     },
     summon_felhunter = {
@@ -1530,19 +1781,28 @@ spec:RegisterAbilities( {
         startsCombat = false,
         texture = 136217,
         handler = function()
-            -- Summon Felhunter
+            state.pet.alive = true
+            state.pet.family = "Felhunter"
         end,
     },
-
-    -- (dispatcher version removed; alias mapping provided in aliases section)
+    summon_observer = {
+        id = 112869,
+        cast = function() return 6 * haste end,
+        cooldown = 0,
+        gcd = "spell",
+        spend = 1,
+        spendType = "soul_shards",
+        startsCombat = false,
+        texture = 538445,
+        handler = function()
+            state.pet.alive = true
+            state.pet.family = "Observer"
+        end,
+    },
 } )
 
 -- Ability aliases for action list compatibility
 spec:RegisterAbilities( {
-    unstable_affliction = { id = 30108, alias = "cast_unstable_affliction" },
-    malefic_grasp = { id = 103103, alias = "cast_malefic_grasp" },
-    seed_of_corruption = { id = 27243, alias = "cast_seed_of_corruption" },
-    -- Generic import alias used by APLs like summon_pet,pet_type=felhunter
     summon_pet = { id = 691, alias = "summon_felhunter" },
 } )
 
@@ -1591,7 +1851,14 @@ spec:RegisterStateExpr( "dark_soul_bonus", function()
 end )
 
 spec:RegisterStateExpr( "spell_power", function()
-    return GetSpellBonusDamage(6) -- Shadow school
+    local sp = ( _GetSpellBonusDamage and _GetSpellBonusDamage( 6 ) ) or 0
+    return sp
+end )
+
+-- Current crit chance for Shadow school; safe during import
+spec:RegisterStateExpr( "crit_pct_current", function()
+    local crit = ( _GetSpellCritChance and _GetSpellCritChance( 6 ) ) or 0
+    return crit
 end )
 
 -- Expose options to APL via state expressions
@@ -1621,54 +1888,53 @@ spec:RegisterRanges( "agony", "fear" )
 -- Options
 spec:RegisterOptions( {
     enabled = true,
-    
+
     aoe = 3,
-    
+
     gcd = 1645,
-    
+
     nameplates = true,
     nameplateRange = 8,
-    
+
     damage = true,
     damageExpiration = 8,
-    
+
     potion = nil,
-    
+
     package = "Affliction",
 } )
 
 -- Settings
-spec:RegisterSetting( "soc_spread", true, {
-    name = strformat( "Enable %s Spread", Hekili:GetSpellLinkWithTexture( 27243 ) ),
-    desc = strformat( "When enabled, the APL may use %s with %s to spread DoTs in AoE. Disable to avoid SoC spread on cleave.",
-        Hekili:GetSpellLinkWithTexture( 27243 ), Hekili:GetSpellLinkWithTexture( 74434 ) ),
-    type = "toggle",
-    width = "full",
-} )
+-- APL currently doesn't support these options, will need tweaks
+-- spec:RegisterSetting( "soc_spread", true, {
+--     name = strformat( "Enable %s Spread", Hekili:GetSpellLinkWithTexture( 27243 ) ),
+--     desc = strformat( "When enabled, the APL may use %s with %s to spread DoTs in AoE. Disable to avoid SoC spread on cleave.",
+--         Hekili:GetSpellLinkWithTexture( 27243 ), Hekili:GetSpellLinkWithTexture( 74434 ) ),
+--     type = "toggle",
+--     width = "full",
+-- } )
 
-spec:RegisterSetting( "preferred_pet", "felhunter", {
-    name = "Preferred Demon (Precombat)",
-    desc = "Which demon to keep active outside combat.",
-    type = "select",
-    width = 1.5,
-    values = function()
-        return {
-            imp = "Imp",
-            voidwalker = "Voidwalker",
-            succubus = "Succubus",
-            felhunter = "Felhunter",
-        }
-    end,
-} )
+-- spec:RegisterSetting( "preferred_pet", "felhunter", {
+--     name = "Preferred Demon (Precombat)",
+--     desc = "Which demon to keep active outside combat.",
+--     type = "select",
+--     width = 1.5,
+--     values = function()
+--         return {
+--             imp = "Imp",
+--             voidwalker = "Voidwalker",
+--             succubus = "Succubus",
+--             felhunter = "Felhunter",
+--         }
+--     end,
+-- } )
 
-spec:RegisterSetting( "auto_resummon_pet", true, {
-    name = "Auto Resummon Preferred Pet (OOC)",
-    desc = "If enabled, precombat recommendations will summon or swap to your preferred demon.",
-    type = "toggle",
-    width = 1.5,
-} )
+-- spec:RegisterSetting( "auto_resummon_pet", true, {
+--     name = "Auto Resummon Preferred Pet (OOC)",
+--     desc = "If enabled, precombat recommendations will summon or swap to your preferred demon.",
+--     type = "toggle",
+--     width = 1.5,
+-- } )
 
 -- Default pack for MoP Affliction Warlock
-spec:RegisterPack( "Affliction", 20250904, [[Hekili:D3ZAVnoos(BjybmCM0TpB540PxehG5MEVDNgyNEX5EV9BwwrMorBKL8jjNEYIa)B)kskrXhfjLSDFyMf98OJezvflwVzrLLtw(1Llwhvrw(lbJdMn(JJVEuW0GBd(WYfvVUJSCXUO4NJEe(lzrBH)7pUztAsCvsEg9vVMMhTMcIY89fXWRxU4H9jPv)C2YhuG7TbxVCr0(QNYlwUyX29BksEE5INswVMWhkPmE5IV(us5Hv0)n6WQAeFyv(g4NzO8WQ0KYk41BYloS6VqEojnzeqhf5BssbS)hoS6FevKMh)8F8WQwk9WQ3Fy1FFhLCwdZTiFlmU8)XIKTLh(mhYLJ2vqIZ3(qu1vZ)pwhv8CyswfjRcFaL73UnplChP6DW)gs5uZ3qsFApmNI3LSz(fvrPWSh9yrY28Kcsy(MWYO4IKnjXKrKSOhsjRhCbm5ru4)c5WNbI)VM)3oS6RfjzptQoS6)jQiHooy9omjlPkjkn5FrxbckPMrKVJKrG)F03IkG)wz5L4u9l1a8D0TY5vC8eoj8H9B2u(U8DZlH1ZlrP7jZh3hieCYqysy5RzXQaOzKJ0i0(a3GUa3G(d3jHBJY2hLEcl5Gthetcj)AC6(1KtagbNbyW3ycxVViIofvif0lqfC(a1UIK8IKQx1Gbv70MiWGZHmhoENWSk8Bhexd)bwjjlg(Y3N(W(ImkqRs2sUly8GlOJFe9nH0xnA)UbSFO8POI1L3pFcoO2LZ2HzlH)z0AsyjPamKbRd2lWN0trGjwbYNm6gvufC4ZmdPsMozwil3gvawltZFmjwayaCXrPPH8FmK6AHtnViMT3HM)y8A)JkPISTdaJKTM6NytYJpv9Usy)iUIV99qEz5GQOIhb3f0fEyvE46ekZVE9(LApadvCUDj4fCr9gg4d8E(pb)3VfTd8AKfdoxPorkRyCNQC4h3Tl91dR(u(xvO3I9ziRDgsviu2UY8zssvRZRkdrKiyK9FRipg2HskFkj7X6TQAXqyNJaUYbAjjJoeGL4LGG4aIdRHwl1mPrcL5vNrhBtazTxbb1A64)okgCUwlrEy1(swCh04qIbbYIg)UukP6j4nF5p)tFIhlYHvpqsZ)wnC(eGHgMSeqEkkBDAdaw81dR(ws1t1cL0DnGoPRFom(Rr0rPfVde)sYwy59cfkadFFC1(cIxgYwycugb8)ziWNayCkjIpd6REHecBWBtiLZdE7n1NCFqRjl(ScJ2L6hdr5iGha2fOqJXq(tza)lMUWPSUI8QioRrIjc7t5zRtyO2pna7AFM)htrWsY)7EctXa(JKfOwblaSBHy7G44cFSiQC37OXjwuSFxTkGvzTbnIJwHRSXvFgvL4)nQyT8qMvsWoAEA3qAyjyrGzOXaPgyXpa5XgVopF7J7bI1C)(UPscpRld5VLhnSyA1Xf3GVaF4ljBdPidINYu8Aoo(AHmtsybaUuyJNBNvws79YcH(e7gvQ4Ns1Uh(EKbpE4AcBNGng4PFl7T3uFwbzlyNO8UzV9w7SlbjU8SbOd82lVeXdY9yJ9QznCegNTSznte8Ggdwkl5oTVpCi2oHkt6Y3EdXx30zxIJq3B8Nic1qPUATsWKIDpgl9H0881P7lRaTO3EJ)isbmPNbwN0ZOdlCZEMjcu6ia2JvOxjPzYVsI3xrc39uuj5YMTnjN8n2ZkrLIFGuXCazvmUpwKMGQKzA)Wuiu2yIaTDXMKd8uZl(5nhwrFc4rf8xUc21kPbhq9jxS(91r7a(03Yd)PjsiQtEs2Jjzenkl6X8m2U(fauhX(jyPe)SP6qCoZPa8aXWBFKL5SpdiayregjQDHyYiVRfkChLBjaRnl(vvrGV9ebSHLbRUp9LVwYdT4f91v)2OndVd33ZPVvFAyIhu2I3ZkmclQwWSoztbPee(hULhofpK5htZFikv3eJy7UD3EhPGguiy2jUGaADa)auqBFFJbxWXYaxZAMt5fnXf7ivAqcm)XbENUo2Ti5ztWZo9GnAbH9HbDhGnoH(P9GrtEIjjXnH(vlst9atF9ADEj9H0uPiPKTayl5ArCFDgVCeUvPPJhSnklA0U4Q7fjA1AbfeIy18emQaJ6rgO09wualBM7c9GeBa8DZH8NXWTKyUInEnmKMSbMdx5rmHmczn9H2HbFPWF2Hv8hQgyZNkyPHWSJ01ffo2WwE3y6wqYcZDx7KXdwXK0I3xYIB)PO0nVVPQrWR3N2Sm)X1CxBrGbX)c1IHi1So6duekN)ajWd96gmwWTDkGXRhedM3ObaAMrrn4VFYSEbFl7sAjxGUqUgdrxBdrmaKrtCFdKggvj7CZDMI7mOxOHBJbKTYiGas5osAQiG32uUTkC4mvqtFx8eXrzJTY8t19rkRLlSC8XzICy)jwkZYzSmmOjpgyXqRQYM98f4281qCIQXcQwvS6eWVsVkJqe)HC3H57O)W7wt2eTpTA(46cnA4cebK)wp(zdcUFXfzgekka7sOT2HGtrUwisXXi3Kqi5xb7MK3f)k8UWA5LUdhuXsiqaKH2R0Hr1FN6XmHavCzuKL0qZq2vJBJ5rHsmT7ccH(7MmAgEc06s9xHT(LcUZkLzMDaseEcA0kXygqikfHfWNvsZrUhUI6ZpX6iAruQ(0uhhWDAlkhHsHQBfaDQ16uxrK1IVS9AfmmIufbb9nY1GX4otoo1Xlu0h9NbF3muz13OcL3edx(FsX720RKCVr9vNVVQXhNU3nLWA5tszRik)86RJdp)2g5JRx7ehLHroE6JItWGsiMyGjbHFKhhwUdYiBTMUZ9ZVXJUdhVXrLvHL0esaXw3wb7gs7SYwNzlNt9AouXDbTn6xdvF2mUYTUxjufSGgEHy43zimz11NhFBn5n9dJhnZenOrolxp(JrcRtYoofxUOHBnuxizADOHY4h1dKH4GdmAU7DRy3RBcFY2iRr33dJ)q6GctOxBGsC7n47hDYYVbpSNvssw080csGJ(ZIthwRy9cVKoT(DeyIw4qR24LBsL6b2lME3Z8(wde5O60OLOuU5fAGrNQBT9ApIbYJSS2DOGIOlGZrX)SfcvnoCkLv36FpNK(pJiRjzLHXqKj0SwB67p7z5vd)nK0WnPqOiDcEgtNxJoQ8zNM)GNirPvpXKF)G5IvqmMnxdeP1cEKvWMeTwIvfrAUeBwRLgrzTMU0vBwj2EeAFA0jWrp(tva6T8zYErTd72k(zPxczRL3E74lDXLDHmukxHkLuldlTtkBiYbxJlbQcmZqsS4MZJgCxiGtjwB7qT1GQ6kBO8og70YLSjdgVVe2dfdXAfsPdSlurtL4vPbHVc6zMWofkQLir9CBT8aBHaA(d1EJehvLOF4(JIULQUhJyLch(lhwfB2toUeVfJwLs1JSQPvj49)0pYHlZkWx2S5WQ)m7m0oS6NQv6AAJPs1UPH2ZCx5T))u8x3Q)HFu9bgqVvHRpaAY1MasOL2la9bdafvehLrhqrbHhoGyF(2XQN)HXCPMYzesFObzda1Wzp48J2mIVRmnVAovMH5DuyLS81SODWyG0VyPIrtc71byTqHfmEP44AwZBC))lwN7T6lGDJTj)lTaPKB4XRupAjJEh56bdrW4SbghZGr1ErM2TxALiqdwBcgqKgWpaS3rqkcx1yYGoolHYzfZwctcbZxpWxStnT)aRXtzkOzV)VxsKBVs1Z)El78(OnjNeRH13QgIn1GqnIA9MqwU8B(75yrNSxx8FKqaE7To4lh36W4lrrjV)774QfVVXfR2aZvBGJoS()3xTbN1vlYE7VNxTEKKr2B)9SKCVVqaTlPtg3b44UlcpU2Lv6b(2w4vRB4L8gYg6v9ROvtSmF7NM3YfVarHaZq(sW9TOcAUxLlx8ZB3LxWUsAtc0647rh(8YfL7iXWmVz2YfShsVNDCmd)TFHDZ9QtGB5)5Yf85ZUjESLe)o1vKSJ)yVCNLlGbd5XMeTCXfhwzSyoSAam7wgYHv3phO8LvajQrkTacHLitNmwhaHQLlOoJCTSAk2I2YYSmnYOVjaRdRUdO1GXUjwJfxaBndmdHONuXkPVcZbpGRdRUM9AtnyaUhwDB7QIntkvn1kvDbRbg1A1WvV9M8JBrnq11HI0Ie2yOi5AFibP02cmzwShlORDGuCoZhoDfeJa5okcKfQazguY5gNKJ9Ae5A)eIZM(2wHn4zthlXq0HhLq(aLqefoA5IjTJxP4sYKO3c5WOdHWADQ9YRxaX3ALd4f8TKOOKqui(XJhImcUTMfmDNpiX6AlKffrtgtXKjnOSabEjpDwmRj5a3yBswlqAywS)wygdAIksqT1WQfXYfJ1S7CoA5gkoHSSbiRRi72oL(gmJjoS2KTCTN46pM1Fs(5Y1GI)CmPCyBjyg)1gwjNQk1P2QHRUuAZulyhV296QpilI9gEeDAcehzUHAJ)lUvUEQn3IW6wSrtrv3uLbIRBFhpWu5iLOAengFq5cQEmNmdXbStBiw2CogFOt7RpuD7qQ()KiYHmcQdEvfhnLQSGWabJoNmc0mU0fXI4O(QdRMHV3WnYHSmK8RIUw6SZBPvLxYgZRVdA3w0ByEJrxeNq0a9zz5mEchRp7gLpvZvShszxTL8IRdoZHceUnUj6gvnnz51UNvzklmgD7Q2J957AixO0M9qq7V1Ql0my5MmNmgXm1KBocNfOIlxqdUGDZErzgArfjFTjXInYuwg7G4yRwyzw7GyChxjkbp54o36oYNURKfyxjZXUR6cdt3YE8kDl(bpOreqH94umSryebwBr6BwVyxSwDkjqIs0UjNUZJtNGqIjuJICI1MRZjxOTSctuvvNsv460UgVNM1bBrMBCDE5(Y0FJC0p1rB3cr(XvYGO1jDlZ1NBVFOZL5Ydr1ZQeHgp39ffUtIVdz)JnrgS9IlDMVYuAuzUvzTl5(9HyCiQ7qH)FNs3t3kIHjwn5Q8J)MmFC(nM40WfU1CR((DwVjp(l8GzlUn0tStlfifM7jF1O1dLtpFk3zk6ictKmECwMj)5o4otexzDzrYSx316tru8IJikgxcKgPO5tI8Ssa4sTgPv5sSTxxNB5LxR8P(LnUMFpZzz1NWdP0huMHMbMkv44MzBsk2Q7(hfKJxWnZMkLrABQ0zxUO2MeS3A1)bbL3DemZVgSnFliPGQwk3UCbZppPTofjTv(PsnXUJc9dXYjcmunv8pBlzT2gVr3mNZR7oJWTxlrbn00gC(iUgYrUuJtS7bXwmi2zp3y3lUI5xXj4PVt1B(xhVJ9SvQT6xILLZrCD4pIBcpk3UdbdpWrok34Ad6wwsi6(IDKsgFBYB)uW9)mZnQnlvtGDNLoe(SumIJ7WIVgJS8CG7YDd3jTzGGA7E2SKPWXu6)(tw9m9j1kNzJ1BAcy6rvVRE85fGTySxRfjFbqea4Nodqxj0EWXvHtAAfiyxlnVs(NryC6ne1HvMjkP1frg78g9seBedDvOrA8eDqXUTwj2Y9ECtjrWjiEtePNC0X04KUQGstdq1DoCaohoWdho43AC4abhwrwlaR2mhp3YI84)wXTSDil9x71IS1VJ1E1SJ5OwtyClCy3hMrFPoBNUpMKpUCsFeS7PKwvBNVG4erXqPRV0Ys5GP9HyL3rJ19BtdLH22lDcc0B3GlZjoNm3zPZsWs)(lBnsH74zgW)mit5wDdTYn)pM4kA3BEo)(o3sNAF7GvwlTmH2tTX8iPTMjfVhrv2R4DWkIkGRZi0ZNgAhRfSfWKXnRaBgWuizLtofPkRke(P)TK(e)ms3NVG0DIVXJuwHJW6wxNL3LNHy7zRWD6qn0R)M7nCh1ED06OUuDd)5SiXwr7fNcMJYL6mrBIe98lyDhrDz1Y6Z1V(6a61wDp)DJIu9nA)9HIWgDZV3tynIj)x8jTtO93pkA(X6YVwuA2vA)LJI8scXmpTRoljsgbA2pfDyPE7BE2(fTICFJQf4aMlLorPMqmOfI6Uj8drBb2Gt60FFPGzC(iWtGD8eiWJUTu)4bLdjc1cXO0rcYajqQBw5ibPiKruBghjqduakwhp7gObwiv6MN4xelmyRhB2Xc7aey3FDA3jhkhFCF0aAstIru9x91BwfNf6Q)gb8sx(Y2XHYScPz)CmQd)sCeg94KqLCSKl1NJ62o4KfYDjVD(1)CLZdwqqPtgDdofj12sn1GSIhmW3ZlDW5)ZGMq(W4qpXYfdToKZT3M49OwXEBTQZxBI78wq1rjsEKJiFXYyp3iuZ5nL0gFbIlEB98mX)KQPWE7nHHVUVWENL7KNJ1gUEVodl1pgJUto4y0tZWymLfgFJVwUyMM8HrtU4Itu3Ya1CDXu5v9clsfDkuG5oEveApXVF4WQXJMzh9opHfAxzIXqD2bo9sZPp6b98crqtYqARziUu)uPMItLOD29KwKTTEVhuiXUiVDlI8w)u)QBZhR1r77td5xF2Qkhw212Ai)E4xW7vW9IE1q(y(doIMGrxD0c282nmx19gBPtN6is8W2p1tF3xaLcu64SeD08i2)gWS0rLzehj(qRfCDwRtl1d72rlRAbu3w3MWD9EH3eRIfWPm4FqCXKz71YFCyyWWElbGiNAxRXcPCTStZtO5iRAfNqpuz)zFyVkR2olbRFy5KJzM9rxdBVZpf1XJMsdB0oWhBRWp(A1h5AJ1T)pJXCA9WTsjOA7nhSiD9tM1ssA3iB1S4vBAlKav9Jg8OOC4RZReS02uDdsJeYPZeXSKgKs2yyPRHeOPFgG8Llq(MDOy94oU)VlfslIP4PNJAMOmblfLfsGN(PyLopPPDphYCOO85RJzHuVnhRt6xHGAAkqSal9toyX0fOOj0wjFMfm2re6WlwtHcup2TJ47ChQxy5EMZ1HDh4QigoDs1xunrYftRLg3(z6no(GeoewTCNdUIqZTJreUv8oQ(r1dZA0Xt(bs9RU4dWNRuzzFp9KXO7VREnX40F6IPkXp1EooRe)z5)h]] )
-
-
+spec:RegisterPack( "Affliction", 20250928, [[Hekili:TR1wVTTVv8plbfqWgTZZ2nojDioaB7L28qFrfyVjjAzkBHOlgusPiag6Z(oKusKI6qzL2KUh2)hAJdVCUXFNRXER8(HN7Esj177RxUEZYVS(UfR285BU(wp3Yxor9CprcFICa(qgjf())zuusCyzCEgFRxsYj75KOiVIfcB7gN(VzKOY6GnxF3F7op3DvXjLFlZBhkBw(f4QNOHWY3SXZ9y8(9u5zPfHEU)4yCrDa)FK6GgbPoipc(DHiuhKexucBhLZQd(k9P4K4fEUIf5sfjNc)47cLK0i0fvPP5z(XzruwgjXZLMr2Lq379V8kbXGFu1kQBLxLSRIbFkKfxszXeUQffTODJf7Z)jipo1bxvhSpVSBd)ckDVFEKFyoJvDItUfLXHpfNDO94sMm6nIZ8b7(HJL(L5(Le2bAP42874xCKW2dwHhQdwcc4lHj0MZuWvEqT(SHAztjQoPRcKd5zVykS8ngQk9Tu(f)KCIZ3RhXCkp0LefC2zvkXv)n2eJbgAD5zwDG9NyBpiWwDY486GZNRdgqN(w5)aaL54MLBSywosQYk1TeJOV7PcDtCLfmAkjodqI3xheskGZgNcoSFeSjmYZ0KMFF642BTIBtjzKfNclf862LkHpjoItfb87olkyeikrjI4zxsjrLRsEaQisvszx4fuHSX4Ksoeh6)CvsgLr2bXOkFrGLucuyfRGYFjPj0uAgWhKyrgEk7sYZ3NuvukWtCGMugxCKsskp2yC2whSwZ6Ckx8Z2qcTlxbChiEAHr4WR1pe3YkyQXH2OFODuqtysxXENYeS1ZWxssaTEbHfEmgIodr)93typLrlkw0CNoFPjDwhXrdpYTiacJBfASrS4SNaJ0jwEi4SustsOHAMWMTlkjcppFBNd3uVAPWRFUYEWfnFbApngmmVmoQUr3oWanlMjqefey7O4qApL7eWCss8ZufNqVeMxGID8R(m1NMrtJPshXBueKvL5l)SppJQmVQVSmaEMvG0F5vPjvN4bicFPvtgKugUllNDOcclWP(QLtaZ864W(88uf9T75AgW2s(Tv29rBJ63bagGX(fHGH5qOw5BLaSjH6QmHmAeJcHwbrssqJuOO7xLbSdwXN0vFx)dohpSTy1HzjrkCIBTSxgYm7IbphyHVm1sJxgQEn65ufjm4iJPzwJO(60BZYGg1dCvFAlWAQsp(dbRSH3TwjfwbDtv5AQhAMbq(efAPiRekvpKrjfujb20vwicCxvXLb44s0YM)rFcIbpVeLNINLfiiEnrRgntQOqm)Uczee2EzzRwSXgR7xmiNV2tBPEnK4unt2V7tPHll47PenXTeIM9uCgpUdKV3omYysQwdgCX1EAtBiMbY97fu8sAccne1QApv9mrRlDfS01L0ul1zIP619vF7PDBqlCskFDMpOAdOpJJG3dLjmr2R2yG9zkc1aULVdkW85gMDHMhuPp6YSy0ur36960AJLoTwpi1(ra845UYZLNIrG(9JJAtuiI0S9ATYKzWXfcK2fexxVKYXsg3legiPxleRbzETiwZgq873UE55ZZWlE4(1ZB2ZsbiQdCPsAuNepu5dR24GgIercSDx8ixTeOxV733mJb5IDzl(iKPy(CNbwPh0BUmfqTG)G)bgP4KX7i)XWS4b5h9tZFM3UO927VB5qG4ajbbx62qzzEZ1I8MQLgYEKXdOKwofU1SDyjB0peihGFAyE6oc6Wb61xi3cLvkN2jlUzau)hcljp8P)rDGAwR1bdgSAVOhkFAjj5DSm6ee(RGYY4K27i5TpMS9UaMSP5102FVXY0m3hdOka9azRGVt3C59C)jHLbEefEUFl9uoRKZ7pBmY9f1pYb65rXjGS8H6auu7JFyaWT(X6hLuQyrNJYh3(31aVFkoA7viiA8lA(QYV9SR6muoxnfJl(PmFD5bmF7OMZfWUZhvFBbwcJLsBNcJXPlQGWP(K0yLRckXLWpT3EyTbZ8KZSlmXu97lPj)sdgh65ZOPZ1VD3ep1xSBcN6lQMOP(QMZ1t8omHrtQGqJDkNznJUC7AqxS1yVAl7JRe1uSA5856kZB9BpqsJHh(j(yd3sYfuLVUAUapCJ(9gojqBYHvyTIkDt7t)1z6ePDafDym9)coghKVSi0ZGPZ8B9akMkZd3m3zgAnGNpBV8o5ExONV5oA1n)WshK)Gx2u0jvC72vder09rkXE7ktHd1PEcIC3JObWBLdYu2CENEbXfQEd4z7QPiKvNCM9)0(fMYOhAP0LGFgpX6gjrhichxJzA502QsVUtStiHLqKCP3yQ(L76QF3B9sP1z3AzNXONEdEcSZDeBDRyyBKsVdVOJjH)FqTAVTvO1utcVnZUKq9hDJdYyBCA7u((n9Ceudz5tD9MdXCeZeHh7rBIiB7nNgzkySGVAh7(R15vVzbCz29xZF5xE(lOGf5qnKju6qd3TuHmgomnnY0naKo6GXe9w5Gk72A8nRQ3M6fpGKZByoCNR4MM2Lg57gJZvnwSXolYxSdl5l0ewR1(jLTEFVJKlH8n3XkDVOva4donry)a2mWeGXVzyMDmt1vnSHJyXngVJpuZnvozHbi6dQSJ9fusRYbTVysJJi0Jd35fD7GJPCDMOa65sQkpMZ8C)kideXuz8(Vd]] )

--- a/UI.lua
+++ b/UI.lua
@@ -1303,7 +1303,8 @@ do
                                 b.Keybinding:SetText(nil)
                             end
 
-                            if conf.glow.enabled and ( i == 1 or conf.glow.queued ) and IsSpellOverlayed( ability.id ) then
+							local overlayAPI = _G.C_SpellActivationOverlay
+							if conf.glow.enabled and ( i == 1 or conf.glow.queued ) and overlayAPI and overlayAPI.IsSpellOverlayed and overlayAPI.IsSpellOverlayed( ability.id ) then
                                 b.glowColor = b.glowColor or {}
 
                                 if conf.glow.coloring == "class" then
@@ -1357,7 +1358,8 @@ if self.HasRecommendations then
                         local a = b.Ability
 
                         if i == 1 or conf.glow.queued then
-                            local glowing = a.id > 0 and IsSpellOverlayed( a.id )
+								local overlayAPI = _G.C_SpellActivationOverlay
+								local glowing = a.id > 0 and overlayAPI and overlayAPI.IsSpellOverlayed and overlayAPI.IsSpellOverlayed( a.id )
 
                             if glowing and not b.glowing then
                                 b.glowColor = b.glowColor or {}


### PR DESCRIPTION
**Changes Made:**

Classes.lua:
- Added `magic_vulnerability` expression to track universal debuff category for +5% spell damage
- Removed `chaos_brand` reference, which is a Demon Hunter ability in Retail and shares the same ID as Curse of Elements

WarlockAffliction.lua & WarlockAffliction.simc:
- Made several optimizations and added expressions to track DoT snapshots and recommend refreshes
- Added `haunt_in_flight` expression to track the time it takes Haunt to fly to its target
- Added or corrected several ability references that were missing or inaccurate

All Paladin luas:
- Attempted to fix an issue referenced in #111 